### PR TITLE
Initial Codemirror lint markers jscs integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,8 @@ function mrdoob() {
 		var hints = document.getElementById('hints');
 		var autocheck = document.getElementById('autocheck');
 
+		var deferredValidator;
+
 		var cmOptions = {
 			value: textarea.value,
 			mode:  'javascript',
@@ -167,7 +169,15 @@ function mrdoob() {
 			autoCloseBrackets: true,
 			showTrailingSpace: true,
 			gutters: [ 'CodeMirror-lint-markers' ],
-			lint: true
+			lint: {
+				async: true,
+				getAnnotations: CodeMirror.jscsAsyncValidator,
+		        requestValidation: function(text, validator) {
+					deferredValidator = validator;
+
+					if (autocheck.checked) validator(text);
+		        }
+		    }
 		};
 
 		var checker, codeEditor;
@@ -192,26 +202,11 @@ function mrdoob() {
 			/*
 			 * Init Code CodeMirror
 			 */
-
 			codeEditor = CodeMirror.fromTextArea( textarea, cmOptions );
-
-			codeEditor.on('change', function() {
-				// scheduleCheck();
-			});
-
-			// scheduleCheck();
 
 		}
 
 		init();
-
-		var scheduledCheck;
-		function scheduleCheck() {
-			if (!autocheck.checked) return;
-
-			if (scheduledCheck) clearTimeout(scheduledCheck);
-			scheduledCheck = setTimeout(check, 200);
-		}
 
 		function hideAnswer() {
 			answer.style.opacity = 0;
@@ -225,9 +220,13 @@ function mrdoob() {
 			setTimeout(hideAnswer, 3000);
 		}
 
-		function check( code ) {
+		function check(code) {
+			code = code ? code : codeEditor.getValue();
+			if (deferredValidator) deferredValidator(code);
+		}
 
-			var code = code ? code : codeEditor.getValue();
+		function jscsCheck( code ) {
+
 			// console.info('checking ' + code + '...');
 
 			if (code.trim().length === 0) {
@@ -268,12 +267,6 @@ function mrdoob() {
 				hints.textContent = '';
 
 			}
-
-			errorList.forEach(function(error) {
-
-				// console.warn(errors.explainError(error));
-
-			});
 
 			return errors;
 

--- a/index.html
+++ b/index.html
@@ -124,14 +124,18 @@ function mrdoob() {
 	-->
 	<script src="jscs-browser.js"></script>
 	<link rel="stylesheet" href="bower_components/codemirror/lib/codemirror.css">
+	<link rel="stylesheet" href="bower_components/codemirror/addon/lint/lint.css">
+
 	<script src="bower_components/codemirror/lib/codemirror.js"></script>
 	<script src="bower_components/codemirror/mode/javascript/javascript.js"></script>
-
-	<script src="bower_components/codemirror/addon/lint/lint.js"></script>
 
 	<script src="bower_components/codemirror/addon/edit/trailingspace.js"></script>
 	<script src="bower_components/codemirror/addon/edit/matchbrackets.js"></script>
 	<script src="bower_components/codemirror/addon/edit/closebrackets.js"></script>
+
+	<script src="bower_components/codemirror/addon/lint/lint.js"></script>
+	<script src="mdcs-lint.js"></script>
+
 
 	<button onclick="check()">Check</button>
 	Auto-check <input type="checkbox" id="autocheck" checked />
@@ -161,28 +165,41 @@ function mrdoob() {
 			lineNumbers: true,
 			matchBrackets: true,
 			autoCloseBrackets: true,
-			showTrailingSpace: true
+			showTrailingSpace: true,
+			gutters: [ 'CodeMirror-lint-markers' ],
+			lint: true
 		};
 
-		var codeEditor = CodeMirror.fromTextArea( textarea, cmOptions );
-
-		var checker = new JscsStringChecker();
-
-		checker.registerDefaultRules();
-		checker.configure({
-			preset: 'mdcs'
-		});
+		var checker, codeEditor;
 
 		var loading = document.getElementById('loading');
 		loading.style.display = 'none';
 
 		function init() {
 
-			codeEditor.on('change', function() {
-				scheduleCheck();
+
+			/*
+			 * Init JSCS Checker
+			 */
+
+			checker = new JscsStringChecker();
+
+			checker.registerDefaultRules();
+			checker.configure({
+				preset: 'mdcs'
 			});
 
-			scheduleCheck();
+			/*
+			 * Init Code CodeMirror
+			 */
+
+			codeEditor = CodeMirror.fromTextArea( textarea, cmOptions );
+
+			codeEditor.on('change', function() {
+				// scheduleCheck();
+			});
+
+			// scheduleCheck();
 
 		}
 
@@ -208,9 +225,9 @@ function mrdoob() {
 			setTimeout(hideAnswer, 3000);
 		}
 
-		function check() {
+		function check( code ) {
 
-			var code = codeEditor.getValue();
+			var code = code ? code : codeEditor.getValue();
 			// console.info('checking ' + code + '...');
 
 			if (code.trim().length === 0) {
@@ -220,9 +237,9 @@ function mrdoob() {
 
 			var errors;
 			try {
-				console.time('check');
+				console.time('jscs check');
 				errors = checker.checkString(code + '\n');
-				console.timeEnd('check');
+				console.timeEnd('jscs check');
 			} catch (e) {
 				
 				// jscs now catches parse error into errorlist, so this shouldn't happen
@@ -254,9 +271,11 @@ function mrdoob() {
 
 			errorList.forEach(function(error) {
 
-				console.warn(errors.explainError(error));
+				// console.warn(errors.explainError(error));
 
 			});
+
+			return errors;
 
 		}
 		

--- a/mdcs-lint.js
+++ b/mdcs-lint.js
@@ -1,0 +1,31 @@
+// code mirror plugin for node-jscs
+
+(function(CodeMirror) {
+	"use strict";
+
+	function validator(text, options) {
+
+		var jscsErrors = check( text );
+		var errorList = jscsErrors.getErrorList();
+
+  		var hintErrors;
+
+  		// convert to Code mirror lint errors format
+		hintErrors = errorList.map(function(error) {
+
+			return {
+				message: error.message
+					+ ' \n(Rule: ' + error.rule + ')'
+					+ '\n' + jscsErrors.explainError(error),
+				severity: 'warning',
+				from: CodeMirror.Pos(error.line - 1, error.column),
+			}
+
+		});
+
+		return hintErrors;
+	}
+
+	CodeMirror.registerHelper("lint", "javascript", validator);
+
+})(CodeMirror);

--- a/mdcs-lint.js
+++ b/mdcs-lint.js
@@ -4,8 +4,7 @@
 	"use strict";
 
 	function validator(text, options) {
-
-		var jscsErrors = check( text );
+		var jscsErrors = jscsCheck( text );
 		var errorList = jscsErrors.getErrorList();
 
   		var hintErrors;
@@ -13,11 +12,11 @@
   		// convert to Code mirror lint errors format
 		hintErrors = errorList.map(function(error) {
 
+			// error.message
 			return {
-				message: error.message
-					+ ' \n(Rule: ' + error.rule + ')'
-					+ '\n' + jscsErrors.explainError(error),
-				severity: 'warning',
+				message: jscsErrors.explainError(error)
+				 + ' \n\n(Rule: ' + error.rule + ')\n ',
+				// severity: 'warning',
 				from: CodeMirror.Pos(error.line - 1, error.column),
 			}
 
@@ -27,5 +26,12 @@
 	}
 
 	CodeMirror.registerHelper("lint", "javascript", validator);
+
+	CodeMirror.jscsAsyncValidator = function(text, updateLinting, options, cm) {
+		options.requestValidation(text, function(text) {
+			var lints = validator(text, options)
+			updateLinting(cm, lints)
+		});
+	}
 
 })(CodeMirror);


### PR DESCRIPTION
![screenshot 2014-12-31 16 28 14](https://cloud.githubusercontent.com/assets/314997/5586516/a4c0db32-910b-11e4-85ea-3d85ad71b337.png)
- "auto-check" isn't really needed since its always called by code mirror's `.validate()` 
- initially thoughts were that this PR can also be a starting point to contribute a jscs-lint addon for CM but the integration was turned out to be really easy /ping @marijnh
